### PR TITLE
Add inactive development status indicator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
 
-This project is no longer actively developed or maintained.
+This project is no longer actively developed or maintained. For similar work, see how to use [Customer managed encryption keys with BigQuery](https://cloud.google.com/bigquery/docs/customer-managed-encryption).
 
 # encrypted-bigquery-client
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+This project is no longer actively developed or maintained.
+
 # encrypted-bigquery-client
 
 The encrypted BigQuery client is an experimental extension of the


### PR DESCRIPTION
I think we should move this to the github.com/googlearchive org, too.

@elibixby are you able to move repos out of the Google org? (I wonder if this repo predates the GoogleCloudPlatform org that it is here and not there.)

@johnrandolph Please take a look.